### PR TITLE
Add pytest configuration and core API tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Foodly
+
+## Running Tests
+
+Install the project requirements:
+
+```bash
+pip install -r requirements.txt
+```
+
+Execute the test suite with:
+
+```bash
+pytest
+```

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+pythonpath = .

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ fastapi
 uvicorn
 jinja2
 python-multipart
+pytest
+httpx

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,61 @@
+import sqlite3
+from importlib import reload
+
+import pytest
+from fastapi.testclient import TestClient
+
+from foodly.core import db as core_db
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    db_path = tmp_path / 'test.db'
+    monkeypatch.setattr(core_db, 'DB_PATH', db_path)
+    from foodly.app import main as app_module
+    reload(app_module)
+    with TestClient(app_module.app) as client:
+        yield client, db_path
+
+
+def test_api_flow(client):
+    client, db_path = client
+    resp = client.post(
+        '/api/foods',
+        data={
+            'name': 'Test Food',
+            'kcal_100g': 100,
+            'prot_100g': 10,
+            'carb_100g': 20,
+            'fat_100g': 5,
+            'fiber_100g': 2,
+            'sugar_100g': 1,
+            'satfat_100g': 1,
+            'sodium_mg_100g': 0,
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    row = conn.execute('SELECT id FROM foods WHERE name=?', ('Test Food',)).fetchone()
+    assert row is not None
+    food_id = row['id']
+
+    resp = client.post('/api/pantry', data={'food_id': food_id, 'qty_g': 200}, follow_redirects=False)
+    assert resp.status_code == 303
+    qty = conn.execute('SELECT qty_g FROM pantry WHERE food_id=?', (food_id,)).fetchone()[0]
+    assert qty == 200
+
+    resp = client.post('/api/consume', data={'food_id': food_id, 'grams': 50}, follow_redirects=False)
+    assert resp.status_code == 303
+    qty_after = conn.execute('SELECT qty_g FROM pantry WHERE food_id=?', (food_id,)).fetchone()[0]
+    assert qty_after == 150
+    grams = conn.execute('SELECT grams FROM consumption_logs WHERE food_id=?', (food_id,)).fetchone()[0]
+    assert grams == 50
+
+    resp = client.get('/api/summary')
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data['totals']['kcal'] > 0
+    conn.close()

--- a/tests/test_compute_targets.py
+++ b/tests/test_compute_targets.py
@@ -1,0 +1,39 @@
+import sqlite3
+import pytest
+
+from foodly.core.calculations import compute_targets
+
+
+def _setup_user_settings(conn: sqlite3.Connection):
+    conn.execute(
+        '''
+        CREATE TABLE user_settings (
+            id INTEGER PRIMARY KEY,
+            weight_kg REAL,
+            height_cm REAL,
+            age INTEGER,
+            sex TEXT,
+            activity_level REAL,
+            kcal_target REAL,
+            protein_g_per_kg REAL,
+            fat_g_per_kg REAL
+        )
+        '''
+    )
+    conn.execute(
+        'INSERT INTO user_settings(id, weight_kg, height_cm, age, sex, activity_level, kcal_target, protein_g_per_kg, fat_g_per_kg) VALUES (1,?,?,?,?,?,?,?,?)',
+        (70, 175, 30, 'M', 1.6, None, 1.8, 0.8)
+    )
+    conn.commit()
+
+
+def test_compute_targets_defaults():
+    conn = sqlite3.connect(':memory:')
+    conn.row_factory = sqlite3.Row
+    _setup_user_settings(conn)
+    targets = compute_targets(conn)
+    assert targets['kcal'] == pytest.approx(2638.0, rel=1e-3)
+    assert targets['prot_g'] == pytest.approx(126.0, rel=1e-3)
+    assert targets['carb_g'] == pytest.approx(407.5, rel=1e-3)
+    assert targets['fat_g'] == pytest.approx(56.0, rel=1e-3)
+    assert targets['fiber_g'] == pytest.approx(36.9, rel=1e-3)

--- a/tests/test_suggest_from_pantry.py
+++ b/tests/test_suggest_from_pantry.py
@@ -1,0 +1,67 @@
+import sqlite3
+
+from foodly.agent.tools import suggest_from_pantry
+
+
+def _setup_db():
+    conn = sqlite3.connect(':memory:')
+    conn.row_factory = sqlite3.Row
+    conn.executescript(
+        '''
+        CREATE TABLE user_settings (
+            id INTEGER PRIMARY KEY,
+            weight_kg REAL,
+            height_cm REAL,
+            age INTEGER,
+            sex TEXT,
+            activity_level REAL,
+            kcal_target REAL,
+            protein_g_per_kg REAL,
+            fat_g_per_kg REAL
+        );
+        INSERT INTO user_settings(id, weight_kg, height_cm, age, sex, activity_level, kcal_target, protein_g_per_kg, fat_g_per_kg)
+            VALUES (1,70,175,30,'M',1.6,NULL,1.8,0.8);
+
+        CREATE TABLE foods (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT,
+            kcal_100g REAL,
+            prot_100g REAL,
+            carb_100g REAL,
+            fat_100g REAL,
+            fiber_100g REAL
+        );
+        INSERT INTO foods(name, kcal_100g, prot_100g, carb_100g, fat_100g, fiber_100g) VALUES
+            ('High Protein', 150, 30, 0, 5, 0),
+            ('High Carb', 120, 5, 80, 2, 2),
+            ('High Fat', 200, 5, 5, 15, 0);
+
+        CREATE TABLE pantry (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            food_id INTEGER,
+            qty_g REAL
+        );
+        INSERT INTO pantry(food_id, qty_g) VALUES (1, 500), (2, 500), (3, 500);
+
+        CREATE TABLE consumption_logs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            ts TEXT,
+            food_id INTEGER,
+            grams REAL,
+            meal TEXT,
+            note TEXT
+        );
+        '''
+    )
+    return conn
+
+
+def test_suggest_from_pantry_prioritizes_carbs():
+    conn = _setup_db()
+    result = suggest_from_pantry(conn)
+    assert result['main_deficit'] == 'carb_g'
+    names = [o['name'] for o in result['options']]
+    assert 'High Carb' in names
+    option = next(o for o in result['options'] if o['name'] == 'High Carb')
+    assert option['grams'] > 0
+    assert option['grams'] <= 500


### PR DESCRIPTION
## Summary
- configure pytest and add requirements for testing
- cover macro target calculations and pantry suggestions with new unit tests
- exercise main FastAPI endpoints through an API flow test

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68acef9da72c8322abc81e07caddffde