### PR TITLE
Use MealType enum for meal logging

### DIFF
--- a/foodly/agent/tools.py
+++ b/foodly/agent/tools.py
@@ -14,7 +14,7 @@ def tool_add_to_pantry(conn: sqlite3.Connection, p: AddToPantry):
 def tool_consume(conn: sqlite3.Connection, c: Consume):
     conn.execute(
         "INSERT INTO consumption_logs(ts, food_id, grams, meal, note) VALUES (?,?,?,?,?)",
-        (datetime.utcnow().isoformat(), c.food_id, c.grams, c.meal, c.note)
+        (datetime.utcnow().isoformat(), c.food_id, c.grams, c.meal.value, c.note)
     )
     # Decremento FIFO
     remaining = c.grams

--- a/foodly/app/main.py
+++ b/foodly/app/main.py
@@ -11,6 +11,7 @@ from fastapi.templating import Jinja2Templates
 
 from foodly.core.db import get_db, init_db
 from foodly.core.calculations import compute_targets
+from foodly.core.models import MealType
 
 APP_DIR = Path(__file__).parent
 TEMPLATES_DIR = APP_DIR / "templates"
@@ -143,7 +144,7 @@ def api_add_pantry(
 def api_consume(
     food_id: int = Form(...),
     grams: float = Form(...),
-    meal: Optional[str] = Form("snack"),
+    meal: MealType = Form(MealType.snack),
     note: Optional[str] = Form(None),
 ):
     grams = max(0.0, grams)
@@ -151,7 +152,7 @@ def api_consume(
     # Log consumption
     conn.execute(
         "INSERT INTO consumption_logs(ts, food_id, grams, meal, note) VALUES (?,?,?,?,?)",
-        (datetime.utcnow().isoformat(), food_id, grams, meal, note)
+        (datetime.utcnow().isoformat(), food_id, grams, meal.value, note)
     )
     # Decrement pantry FIFO by created_at
     remaining = grams

--- a/foodly/core/models.py
+++ b/foodly/core/models.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from typing import Any, Dict, List, Optional
+from enum import Enum
 
 from pydantic import BaseModel, Field
 
@@ -10,10 +11,17 @@ class AddToPantry(BaseModel):
     location: Optional[str] = None
     best_before: Optional[str] = Field(None, description="YYYY-MM-DD")
 
+class MealType(str, Enum):
+    breakfast = "breakfast"
+    lunch = "lunch"
+    dinner = "dinner"
+    snack = "snack"
+
+
 class Consume(BaseModel):
     food_id: int
     grams: float = Field(..., gt=0)
-    meal: Optional[str] = Field("snack", enum=["breakfast","lunch","dinner","snack"])  # type: ignore
+    meal: MealType = MealType.snack
     note: Optional[str] = None
 
 class FindFood(BaseModel):


### PR DESCRIPTION
## Summary
- add `MealType` enum for the four meal options
- type `Consume` and app consumption endpoint with `MealType`
- ensure database writes use `meal.value`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68acef9c2cc88322ae276978d1e89713