### PR TITLE
Support ml units and multipack parsing in rule engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# Foodly
+
+Prototype di coach nutrizionale con interfaccia conversazionale.
+
+## Limitazioni
+- Parser rule-based con dizionario e pattern limitati; le frasi troppo complesse o con alimenti non noti possono non essere riconosciute.
+- Tutte le quantità sono normalizzate in grammi; per i liquidi `ml` sono convertiti 1:1 in grammi.
+
+## Fallback verso LLM
+Quando il parser non è sufficiente o `use_rule_based=false`, l'applicazione delega la comprensione a un modello linguistico. È necessario fornire una chiave API (`FOODLY_API`) nelle impostazioni. Nel prototipo l'invocazione del modello non è ancora implementata.

--- a/foodly/agent/main.py
+++ b/foodly/agent/main.py
@@ -73,8 +73,27 @@ TOOLS_SCHEMA = [
 
 ADD_PAT = re.compile(r"aggiung[ei]|metti(?: .+)? in dispensa", re.I)
 CONS_PAT = re.compile(r"(ho )?(mangiato|consumato|usa|consuma)", re.I)
-GRAMS_PAT = re.compile(r"(\d+)(?:\s)?g\b", re.I)
-QTY_PAT = re.compile(r"(\d+)\s*(?:x|scatolette?|confezioni?)", re.I)
+# numeri seguiti da g o ml
+GRAMS_PAT = re.compile(r"(\d+)(?:\s)?(g|ml)\b", re.I)
+# es. "2 x", "2 vasetti", "2 bottiglie"
+QTY_PAT = re.compile(
+    r"(\d+)\s*(?:x|scatolette?|confezioni?|vasetti|lattine|bottiglie)", re.I
+)
+# es. "2 vasetti da 125 g"
+MULTI_PAT = re.compile(
+    r"(\d+)\s*(?:x|scatolette?|confezioni?|vasetti|lattine|bottiglie).*?da\s*(\d+)\s*(g|ml)",
+    re.I,
+)
+
+FOOD_KEYS = [
+    "tonno",
+    "gallette",
+    "prosciutto",
+    "riso",
+    "pollo",
+    "yogurt",
+    "latte",
+]
 
 
 def naive_parse(conn: sqlite3.Connection, text: str) -> List[ToolCall]:
@@ -87,18 +106,22 @@ def naive_parse(conn: sqlite3.Connection, text: str) -> List[ToolCall]:
 
     if ADD_PAT.search(text):
         grams = 0.0
-        m = GRAMS_PAT.search(text)
-        if m:
-            grams = float(m.group(1))
-        # Prova quantità per unità (es. 2 scatolette da 56 g)
-        mq = QTY_PAT.search(text)
-        if mq and grams == 0.0:
+        mq = MULTI_PAT.search(text)
+        if mq:
             qty = float(mq.group(1))
-            # deduci 56 g se parla di tonno
-            grams = qty * (56.0 if "tonno" in text.lower() else 100.0)
+            grams = qty * float(mq.group(2))
+        else:
+            m = GRAMS_PAT.search(text)
+            if m:
+                grams = float(m.group(1))
+            mq = QTY_PAT.search(text)
+            if mq and grams == 0.0:
+                qty = float(mq.group(1))
+                # deduci 56 g se parla di tonno
+                grams = qty * (56.0 if "tonno" in text.lower() else 100.0)
         # identifica food
         food = None
-        for key in ["tonno", "gallette", "prosciutto", "riso", "pollo", "yogurt"]:
+        for key in FOOD_KEYS:
             if key in text.lower():
                 food = key; break
         if food is None:
@@ -117,7 +140,7 @@ def naive_parse(conn: sqlite3.Connection, text: str) -> List[ToolCall]:
         if m:
             grams = float(m.group(1))
         food = None
-        for key in ["tonno", "gallette", "prosciutto", "riso", "pollo", "yogurt"]:
+        for key in FOOD_KEYS:
             if key in text.lower():
                 food = key; break
         fid = find_id(food) if food else None

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -1,0 +1,47 @@
+import sqlite3
+import pytest
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from foodly.agent.main import naive_parse
+from foodly.core.models import AddToPantry, Consume
+
+@pytest.fixture
+def conn():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute("CREATE TABLE foods (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)")
+    foods = [
+        ("Latte parzialmente scremato",),
+        ("Yogurt bianco",),
+        ("Tonno al naturale",),
+    ]
+    conn.executemany("INSERT INTO foods(name) VALUES (?)", foods)
+    yield conn
+    conn.close()
+
+def test_parse_ml(conn):
+    text = "aggiungi 200 ml di latte"
+    actions = naive_parse(conn, text)
+    assert len(actions) == 1
+    a = actions[0]
+    assert a.name == "add_to_pantry"
+    assert a.arguments["qty_g"] == 200.0
+
+def test_parse_multipack(conn):
+    text = "aggiungi 2 vasetti di yogurt da 125 g"
+    actions = naive_parse(conn, text)
+    assert len(actions) == 1
+    a = actions[0]
+    assert a.name == "add_to_pantry"
+    assert a.arguments["qty_g"] == 250.0
+
+def test_parse_consume(conn):
+    text = "ho mangiato 150 g di tonno"
+    actions = naive_parse(conn, text)
+    assert len(actions) == 1
+    a = actions[0]
+    assert a.name == "consume"
+    assert a.arguments["grams"] == 150.0


### PR DESCRIPTION
## Summary
- parse `ml` amounts and multipack expressions in rule-based agent
- extend known food keywords
- document limitations and LLM fallback
- add unit tests covering ml, multipack and consumption phrases

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68acef9ac33c832286a68c81ad5eaaeb